### PR TITLE
feat: put external IP and swarm port into environment variables in the IPFS image

### DIFF
--- a/request-node/templates/statefulSet.yaml
+++ b/request-node/templates/statefulSet.yaml
@@ -92,6 +92,14 @@ spec:
         # Forces the IPFS node to connect to the Request dedicated network
         - name: LIBP2P_FORCE_PNET
           value: "1"
+        {{- if .Values.ipfs.swarm.externalIP }}
+        - name: SWARM_EXTERNAL_IP
+          value: .Values.ipfs.swarm.externalIP
+        {{- end }}
+        {{- if .Values.ipfs.swarm.port }}
+        - name: SWARM_PORT
+          value: .Values.ipfs.swarm.port
+        {{- end }}
         resources:
           {{ toYaml .Values.resources.ipfs | indent 12 }}
 

--- a/request-node/templates/statefulSet.yaml
+++ b/request-node/templates/statefulSet.yaml
@@ -93,7 +93,7 @@ spec:
         - name: LIBP2P_FORCE_PNET
           value: "1"
         {{- if .Values.ipfs.swarm.externalIP }}
-        - name: SWARM_EXTERNAL_IP
+        - name: EXTERNAL_IP
           value: .Values.ipfs.swarm.externalIP
         {{- end }}
         {{- if .Values.ipfs.swarm.port }}


### PR DESCRIPTION
## Description

The IPFS image announces the address $EXTERNAL_IP to the IPFS dedicated network. Therefore we allows to define this environment variable from Helm

https://requestnetwork.atlassian.net/browse/PROT-1173