### PR TITLE
chore(request-node): update liveness probes

### DIFF
--- a/request-node/Chart.yaml
+++ b/request-node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 0.6.6
 description: A Helm chart for Request Node
 name: request-node
-version: 0.6.12
+version: 0.6.13
 keywords:
   - request
   - ipfs

--- a/request-node/templates/statefulSet.yaml
+++ b/request-node/templates/statefulSet.yaml
@@ -30,27 +30,23 @@ spec:
           containerPort: {{ .Values.port }}
           protocol: TCP
         livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-          {{- if  .Values.livenessProbe }}
-          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds}}
-          {{- end }}
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: http
-          {{- if  .Values.readinessProbe }}
-          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds}}
-          {{- end }}
+          exec:
+            command:
+              - /usr/bin/wget
+              - --no-verbose
+              - --tries=1
+              - --spider
+              - http://localhost:{{ .Values.port }}/healthz
         startupProbe:
-          httpGet:
-            path: /readyz
-            port: http
-          {{- if  .Values.startupProbe }}
+          exec:
+            command:
+              - /usr/bin/wget
+              - --no-verbose
+              - --tries=1
+              - --spider
+              - http://localhost:{{ .Values.port }}/readyz
           periodSeconds: {{ .Values.startupProbe.periodSeconds}}
           failureThreshold: {{ .Values.startupProbe.failureThreshold}}
-          {{- end }}
         resources:
           {{- toYaml .Values.resources.node | nindent 12 }}
         volumeMounts:
@@ -84,14 +80,9 @@ spec:
         imagePullPolicy: {{ .Values.ipfs.image.pullPolicy }}
         livenessProbe:
           tcpSocket:
-              port: swarm
+            port: swarm
           initialDelaySeconds: 15
           timeoutSeconds: 5
-          periodSeconds: 3
-        readinessProbe:
-          tcpSocket:
-              port: swarm
-          initialDelaySeconds: 15
           periodSeconds: 3
         ports:
         - containerPort: {{ .Values.ipfs.swarm.port }}

--- a/request-node/values.yaml
+++ b/request-node/values.yaml
@@ -116,6 +116,6 @@ ingress:
   hosts:
   tls:
 
-readinessProbe: {}
-livenessProbe: {}
-startupProbe: {}
+startupProbe:
+  failureThreshold: 125
+  periodSeconds: 10


### PR DESCRIPTION
## Description

- Use `wget` instead of `httpGet` because of https://github.com/kubernetes/kubernetes/issues/89898
- Remove the `readinessProbe` from the node container because once the node is initialized, it is initialized forever, and the `startupProbe` is already taking care of checking for initialization.
- Remove the `readinessProbe` from the ipfs container because the `livenessProbe` is already doing the same check, so if the check fails the container will restart anyway.
- Remove the node container's `livenessProbe.initialDelaySeconds` because the `livenessProbe` won't start before the `startupProbe` has succeeded.
- Add default values for the `startupProbe`
- Remove the `readinessProbe` and `livenessProbe` values, because they are not used anywhere anymore

## Checklist
- [x] Bump Chart version
- [ ] If new Chart, added to `.circleci/config.yml`
