### PR TITLE
chore(statefulSets): configure fsGroupChangePolicy

### DIFF
--- a/request-ipfs/Chart.yaml
+++ b/request-ipfs/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: '0.3.0'
+appVersion: 0.4.26
 description: A Helm chart for a dedicated Request IPFS node
 name: request-ipfs
-version: 0.6.10
+version: 0.6.11
 keywords:
   - request
   - ipfs

--- a/request-ipfs/templates/statefulSet.yaml
+++ b/request-ipfs/templates/statefulSet.yaml
@@ -18,6 +18,8 @@ spec:
       securityContext:
         # The image runs as uid 1000 by default, and needs to be able to write to the persistent volume to be able to start.
         fsGroup: 1000
+        # Shorten the time it takes to change ownership and permission of files on boot.
+        fsGroupChangePolicy: "OnRootMismatch"
         runAsUser: 1000
 
       containers:

--- a/request-node/Chart.yaml
+++ b/request-node/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 0.6.6
+appVersion: 0.8.0
 description: A Helm chart for Request Node
 name: request-node
-version: 0.6.17
+version: 0.6.18
 keywords:
   - request
   - ipfs

--- a/request-node/templates/statefulSet.yaml
+++ b/request-node/templates/statefulSet.yaml
@@ -18,6 +18,8 @@ spec:
       securityContext:
         # The image runs as uid 1000 by default, and needs to be able to write to the persistent volume to be able to start.
         fsGroup: 1000
+        # Shorten the time it takes to change ownership and permission of files on boot.
+        fsGroupChangePolicy: "OnRootMismatch"
         runAsUser: 1000
 
       containers:


### PR DESCRIPTION
## Description
This PR aims to reduce the boot time of our nodes (both Request Node and IPFS node). It takes a long time for a node to restart as Kubernetes has to `chmod` every single file contained in the volumes. After this change, this process will only happen if the root-containing directory has the wrong permissions.

## References
- https://github.com/kubernetes/kubernetes/issues/110158#issuecomment-1276210255
- https://blog.devgenius.io/when-k8s-pods-are-stuck-mounting-large-volumes-2915e6656cb8

## Checklist
- [x] Bump Chart version
- [ ] If new Chart, added to `.circleci/config.yml`
