### PR TITLE
feat: request node 0.29.0 + tag defaults to appVersion

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,13 +1,15 @@
 name: Helm Charts build & deploy
 
-on: push
+on:
+  push:
+    branches: main
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        chart:  [request-node, request-ipfs]
+        chart: [request-node, request-ipfs]
     steps:
       - uses: actions/checkout@v3
       - uses: azure/setup-helm@v3

--- a/.github/workflows/new-version.yaml
+++ b/.github/workflows/new-version.yaml
@@ -1,0 +1,31 @@
+name: New image version
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        type: choice
+        required: true
+        options:
+          - request-node
+          - request-ipfs
+      version:
+        type: string
+        required: true
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: patch image
+        uses: mikefarah/yq@v4.35.2
+        with:
+          cmd: yq -i '.appVersion = "${{ inputs.version }}"' ./${{ inputs.package }}/Chart.yaml
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: "feat(${{ inputs.package }}): update to ${{ inputs.version }}"
+          title: "feat(${{ inputs.package }}): update to ${{ inputs.version }}"
+          reviewers: ${{ github.actor }}
+          branch: patch/${{ inputs.package }}-${{ inputs.version }}

--- a/request-ipfs/templates/statefulSet.yaml
+++ b/request-ipfs/templates/statefulSet.yaml
@@ -24,7 +24,7 @@ spec:
 
       containers:
       - name: ipfs
-        image: "{{ .Values.image.image }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.image.image }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         livenessProbe:
           tcpSocket:

--- a/request-ipfs/values.yaml
+++ b/request-ipfs/values.yaml
@@ -15,8 +15,9 @@ resources: {}
 # The IPFS image information
 image:
   image: requestnetwork/request-ipfs
-  tag: 0.4.26
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
+  # defaults to Chart.AppVersion
+  # tag:
 # IPFS swarm port
 swarm:
   port: 4001

--- a/request-node/Chart.yaml
+++ b/request-node/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 0.8.0
+appVersion: 0.29.0
 description: A Helm chart for Request Node
 name: request-node
-version: 0.6.19
+version: 0.7.0
 keywords:
   - request
   - ipfs

--- a/request-node/Chart.yaml
+++ b/request-node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 0.8.0
 description: A Helm chart for Request Node
 name: request-node
-version: 0.6.18
+version: 0.6.19
 keywords:
   - request
   - ipfs

--- a/request-node/templates/statefulSet.yaml
+++ b/request-node/templates/statefulSet.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
       # Request Node Container
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.nodeImage.image }}:{{ .Values.nodeImage.tag }}"
+        image: "{{ .Values.nodeImage.image }}:{{ .Values.nodeImage.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.nodeImage.pullPolicy }}
         ports:
         - name: http

--- a/request-node/templates/statefulSet.yaml
+++ b/request-node/templates/statefulSet.yaml
@@ -73,11 +73,9 @@ spec:
             value: {{ required "nodeEnv.networkId is required" .Values.nodeEnv.networkId | quote }}
           - name: LOG_LEVEL
             value: {{ .Values.nodeEnv.logLevel }}
-          - name: IPFS_PORT
-            value: {{ .Values.ipfs.api.port | quote  }}
           {{ if not .Values.ipfs.sidecar }}
-          - name: IPFS_HOST
-            value: {{ required "ipfs.api.host is required when IPFS is not a sidecar" .Values.ipfs.api.host | quote }}
+          - name: IPFS_URL
+            value: {{ required "ipfs.api.url is required when IPFS is not a sidecar" .Values.ipfs.api.url | quote }}
           {{ end }}
           - name: INITIALIZATION_STORAGE_FILE_PATH
             value: {{ .Values.nodeEnv.initializationStorageFilePath }}

--- a/request-node/values.yaml
+++ b/request-node/values.yaml
@@ -35,8 +35,8 @@ nodeIndexDirectoryPath: /index
 # The Request Node image information
 nodeImage:
   image: requestnetwork/request-node
-  tag: 0.8.0
-  pullPolicy: Always
+  tag: 0.27.0
+  pullPolicy: IfNotPresent
 
 # Name override
 nameOverride: ""
@@ -75,7 +75,7 @@ ipfs:
   # IPFS API port
   api:
     # required if `ipfs.sidecar` is false
-    host: 
+    url:
     port: 5001
     # The ipfs API service type and port
     service:

--- a/request-node/values.yaml
+++ b/request-node/values.yaml
@@ -35,7 +35,7 @@ nodeIndexDirectoryPath: /index
 # The Request Node image information
 nodeImage:
   image: requestnetwork/request-node
-  tag: 0.27.0
+  tag: 0.29.0
   pullPolicy: IfNotPresent
 
 # Name override

--- a/request-node/values.yaml
+++ b/request-node/values.yaml
@@ -35,8 +35,9 @@ nodeIndexDirectoryPath: /index
 # The Request Node image information
 nodeImage:
   image: requestnetwork/request-node
-  tag: 0.29.0
   pullPolicy: IfNotPresent
+  # defaults to Chart.AppVersion
+  # tag:
 
 # Name override
 nameOverride: ""


### PR DESCRIPTION
This release is a breaking change and requires configuration update

Included in this PR:
- use the Chart.AppVersion as the default tag
- introduce a new GH action to patch the AppVersion, for easy update