### PR TITLE
fix(request-node): missing IPFS sidecar loadBalancerIP

### DIFF
--- a/charts/request-ipfs/README.md
+++ b/charts/request-ipfs/README.md
@@ -28,14 +28,16 @@ $ helm install --name my-release request/request-ipfs
 
 The following table lists the configurable parameters of the Request IPFS chart and their default values.
 
-| Parameter             | Description                                       | Default                       |
-| --------------------- | ------------------------------------------------- | ----------------------------- |
-| `replicaCount`        | The amount of replicas to run                     | `1`                           |
-| `image.image`         | The docker image for the dedicated IPFS node      | `requestnetwork/request-ipfs` |
-| `image.tag`           | The version tag for the dedicated IPFS node image | `0.4.26`                      |
-| `image.pullPolicy`    | Dedicated IPFS node image pull policy             | `Always`                      |
-| `identity.peerId`     | The IPFS node PeerID (optional)                   | ``                            |
-| `identity.privateKey` | The IPFS node Private Key (optional)              | ``                            |
+| Parameter              | Description                                                                                      | Default                       |
+|------------------------|--------------------------------------------------------------------------------------------------|-------------------------------|
+| `replicaCount`         | The amount of replicas to run                                                                    | `1`                           |
+| `image.image`          | The docker image for the dedicated IPFS node                                                     | `requestnetwork/request-ipfs` |
+| `image.tag`            | The version tag for the dedicated IPFS node image                                                | `0.4.26`                      |
+| `image.pullPolicy`     | Dedicated IPFS node image pull policy                                                            | `Always`                      |
+| `swarm.loadBalancerIP` | Static IP address used by the load balancer (optional)                                           |                               |
+| `swarm.externalIP`     | Swarm address to announce to the network. Usually same as `ipfs.swarm.loadBalancerIP` (optional) |                               |
+| `identity.peerId`      | The IPFS node PeerID (optional)                                                                  | ``                            |
+| `identity.privateKey`  | The IPFS node Private Key (optional)                                                             | ``                            |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/charts/request-ipfs/values.yaml
+++ b/charts/request-ipfs/values.yaml
@@ -21,7 +21,7 @@ image:
 # IPFS swarm port
 swarm:
   port: 4001
-  loadBalancerIP: 
+  loadBalancerIP:
 # IPFS API port
 api:
   port: 5001

--- a/charts/request-node/README.md
+++ b/charts/request-node/README.md
@@ -28,22 +28,23 @@ $ helm install --name my-release request/request-node
 
 The following table lists the configurable parameters of the Request Node chart and their default values.
 
-| Parameter                  | Description                                           | Default                       |
-| -------------------------- | ----------------------------------------------------- | ----------------------------- |
-| `nodeEnv.mnemonic`         | The mnemonic of a wallet for gas fees                 | **Required value**            |
-| `nodeEnv.web3ProviderUrl`  | The URL of the Web3 provider (infura for instance)    | **Required value**            |
-| `nodeEnv.networkId`        | The ethereum network (0 custom, 1 mainnet, 4 rinkeby) | **Required value**            |
-| `nodeEnv.logLevel`         | The node log level (ERROR, WARN, INFO or DEBUG)       | `DEBUG`                       |
-| `replicaCount`             | The amount of replicas to run                         | `1`                           |
-| `nodeImage.image`          | The docker image for the Request Node                 | `requestnetwork/request-node` |
-| `nodeImage.tag`            | The version tag for the Request Node image            | `0.5.5`                       |
-| `nodeImage.pullPolicy`     | Request Node image pull policy                        | `Always`                      |
-| `ipfs.image.image`         | The docker image for the dedicated IPFS server        | `requestnetwork/request-ipfs` |
-| `ipfs.image.tag`           | The version tag for the dedicated IPFS server image   | `0.3.4`                       |
-| `ipfs.image.pullPolicy`    | Dedicated IPFS server image pull policy               | `Always`                      |
-| `ipfs.swarm.externalIP`    | The IPFS swarm announce external IP (optional)        | ``                            |
-| `ipfs.identity.peerId`     | The IPFS node PeerID (optional)                       | ``                            |
-| `ipfs.identity.privateKey` | The IPFS node Private Key (optional)                  | ``                            |
+| Parameter                   | Description                                                                                      | Default                       |
+|-----------------------------|--------------------------------------------------------------------------------------------------|-------------------------------|
+| `nodeEnv.mnemonic`          | The mnemonic of a wallet for gas fees                                                            | **Required value**            |
+| `nodeEnv.web3ProviderUrl`   | The URL of the Web3 provider (infura for instance)                                               | **Required value**            |
+| `nodeEnv.networkId`         | The ethereum network (0 custom, 1 mainnet, 4 rinkeby)                                            | **Required value**            |
+| `nodeEnv.logLevel`          | The node log level (ERROR, WARN, INFO or DEBUG)                                                  | `DEBUG`                       |
+| `replicaCount`              | The amount of replicas to run                                                                    | `1`                           |
+| `nodeImage.image`           | The docker image for the Request Node                                                            | `requestnetwork/request-node` |
+| `nodeImage.tag`             | The version tag for the Request Node image                                                       | `0.5.5`                       |
+| `nodeImage.pullPolicy`      | Request Node image pull policy                                                                   | `Always`                      |
+| `ipfs.image.image`          | The docker image for the dedicated IPFS server                                                   | `requestnetwork/request-ipfs` |
+| `ipfs.image.tag`            | The version tag for the dedicated IPFS server image                                              | `0.3.4`                       |
+| `ipfs.image.pullPolicy`     | Dedicated IPFS server image pull policy                                                          | `Always`                      |
+| `ipfs.swarm.loadBalancerIP` | Static IP address used by the load balancer (optional)                                           |                               |
+| `ipfs.swarm.externalIP`     | Swarm address to announce to the network. Usually same as `ipfs.swarm.loadBalancerIP` (optional) |                               |
+| `ipfs.identity.peerId`      | The IPFS node PeerID (optional)                                                                  |                               |
+| `ipfs.identity.privateKey`  | The IPFS node Private Key (optional)                                                             |                               |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/charts/request-node/templates/ipfs-swarm-load-balancer.yaml
+++ b/charts/request-node/templates/ipfs-swarm-load-balancer.yaml
@@ -13,6 +13,7 @@ spec:
     port: {{ .Values.ipfs.swarm.port }}
     protocol: TCP
     targetPort: 4001
+  loadBalancerIP: {{ .Values.swarm.loadBalancerIP }}
   selector:
 {{ include "request-node.labels" . | indent 4 }}
   sessionAffinity: None

--- a/charts/request-node/values.yaml
+++ b/charts/request-node/values.yaml
@@ -73,6 +73,8 @@ ipfs:
   # IPFS swarm port
   swarm:
     port: 4001
+    loadBalancerIP:
+    externalIP:
   # IPFS API port
   api:
     # required if `ipfs.sidecar` is false


### PR DESCRIPTION
## Description

Like with the [IPFS chart](https://github.com/RequestNetwork/request-helm-charts/blob/main/charts/request-ipfs/templates/ipfs-swarm-load-balancer.yaml#L14), we should give the option to assign a load balancer IP for the request node's IPFS sidecar.

## Checklist
- [ ] Bump Chart version


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new configurable parameters: `swarm.loadBalancerIP` and `swarm.externalIP` for enhanced network accessibility in the Request IPFS and Request Node Helm Charts.
- **Documentation**
	- Updated README files to reflect new parameters and clarify existing ones.
- **Configuration Changes**
	- Adjusted the `values.yaml` files to include new fields for load balancing and external access, improving the deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->