### PR TITLE
feat: add support for extra env vars

### DIFF
--- a/charts/request-ipfs/Chart.yaml
+++ b/charts/request-ipfs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.4.26
 description: A Helm chart for a dedicated Request IPFS node
 name: request-ipfs
-version: 0.6.11
+version: 0.6.12
 keywords:
   - request
   - ipfs

--- a/charts/request-ipfs/README.md
+++ b/charts/request-ipfs/README.md
@@ -34,11 +34,11 @@ The following table lists the configurable parameters of the Request IPFS chart 
 | `image.image`          | The docker image for the dedicated IPFS node                                                     | `requestnetwork/request-ipfs` |
 | `image.tag`            | The version tag for the dedicated IPFS node image                                                | `0.4.26`                      |
 | `image.pullPolicy`     | Dedicated IPFS node image pull policy                                                            | `Always`                      |
-| `swarm.loadBalancerIP` | Static IP address used by the load balancer (optional)                                           |                               |
-| `swarm.externalIP`     | Swarm address to announce to the network. Usually same as `ipfs.swarm.loadBalancerIP` (optional) |                               |
-| `identity.peerId`      | The IPFS node PeerID (optional)                                                                  |                               |
-| `identity.privateKey`  | The IPFS node Private Key (optional)                                                             |                               |
-| `extraEnvs`            | Additional environment variables to pass down to the IPFS node (optional)                        |                               |
+| `swarm.loadBalancerIP` | Static IP address used by the load balancer (optional)                                           | `null`                        |
+| `swarm.externalIP`     | Swarm address to announce to the network. Usually same as `ipfs.swarm.loadBalancerIP` (optional) | `null`                        |
+| `identity.peerId`      | The IPFS node PeerID (optional)                                                                  | `null`                        |
+| `identity.privateKey`  | The IPFS node Private Key (optional)                                                             | `null`                        |
+| `extraEnvs`            | Additional environment variables to pass down to the IPFS node (optional)                        | `[]`                          |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/charts/request-ipfs/README.md
+++ b/charts/request-ipfs/README.md
@@ -28,17 +28,17 @@ $ helm install --name my-release request/request-ipfs
 
 The following table lists the configurable parameters of the Request IPFS chart and their default values.
 
-| Parameter              | Description                                                                                      | Default                       |
-|------------------------|--------------------------------------------------------------------------------------------------|-------------------------------|
-| `replicaCount`         | The amount of replicas to run                                                                    | `1`                           |
+| Parameter              | Description                                                                                      | Default                     |
+|------------------------|--------------------------------------------------------------------------------------------------|-----------------------------|
+| `replicaCount`         | The amount of replicas to run                                                                    | `1`                         |
 | `image.image`          | The docker image for the dedicated IPFS node                                                     | `requestnetwork/request-ipfs` |
-| `image.tag`            | The version tag for the dedicated IPFS node image                                                | `0.4.26`                      |
-| `image.pullPolicy`     | Dedicated IPFS node image pull policy                                                            | `Always`                      |
-| `swarm.loadBalancerIP` | Static IP address used by the load balancer (optional)                                           | `null`                        |
-| `swarm.externalIP`     | Swarm address to announce to the network. Usually same as `ipfs.swarm.loadBalancerIP` (optional) | `null`                        |
-| `identity.peerId`      | The IPFS node PeerID (optional)                                                                  | `null`                        |
-| `identity.privateKey`  | The IPFS node Private Key (optional)                                                             | `null`                        |
-| `extraEnvs`            | Additional environment variables to pass down to the IPFS node (optional)                        | `[]`                          |
+| `image.tag`            | The version tag for the dedicated IPFS node image                                                | `0.4.26`                    |
+| `image.pullPolicy`     | Dedicated IPFS node image pull policy                                                            | `Always`                    |
+| `swarm.loadBalancerIP` | Static IP address used by the load balancer (optional)                                           | `null`                      |
+| `swarm.externalIP`     | Swarm address to announce to the network. Usually same as `ipfs.swarm.loadBalancerIP` (optional) | `null`                      |
+| `identity.peerId`      | The IPFS node PeerID (optional)                                                                  | `null`                      |
+| `identity.privateKey`  | The IPFS node Private Key (optional)                                                             | `null`                      |
+| `extraEnvs`            | Additional environment variables to pass down to the IPFS node (optional)                        | `{}`                          |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/charts/request-ipfs/README.md
+++ b/charts/request-ipfs/README.md
@@ -36,8 +36,9 @@ The following table lists the configurable parameters of the Request IPFS chart 
 | `image.pullPolicy`     | Dedicated IPFS node image pull policy                                                            | `Always`                      |
 | `swarm.loadBalancerIP` | Static IP address used by the load balancer (optional)                                           |                               |
 | `swarm.externalIP`     | Swarm address to announce to the network. Usually same as `ipfs.swarm.loadBalancerIP` (optional) |                               |
-| `identity.peerId`      | The IPFS node PeerID (optional)                                                                  | ``                            |
-| `identity.privateKey`  | The IPFS node Private Key (optional)                                                             | ``                            |
+| `identity.peerId`      | The IPFS node PeerID (optional)                                                                  |                               |
+| `identity.privateKey`  | The IPFS node Private Key (optional)                                                             |                               |
+| `extraEnvs`            | Additional environment variables to pass down to the IPFS node (optional)                        |                               |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/charts/request-ipfs/templates/statefulSet.yaml
+++ b/charts/request-ipfs/templates/statefulSet.yaml
@@ -67,6 +67,10 @@ spec:
                 name: {{ include "request-ipfs.fullname" . }}-secret
                 key: ipfsPrivateKey
         {{- end }}
+        {{- range $key, $value := .Values.extraEnv }}
+        - name: {{ $key }}
+          value: {{ tpl $value $ | quote }}
+        {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
 
@@ -82,7 +86,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-      
+
   volumeClaimTemplates:
   # IPFS storage volume
   - metadata:

--- a/charts/request-ipfs/templates/statefulSet.yaml
+++ b/charts/request-ipfs/templates/statefulSet.yaml
@@ -67,6 +67,7 @@ spec:
                 name: {{ include "request-ipfs.fullname" . }}-secret
                 key: ipfsPrivateKey
         {{- end }}
+        # Set additional environment variables for the IPFS container
         {{- range $key, $value := .Values.extraEnv }}
         - name: {{ $key }}
           value: {{ tpl $value $ | quote }}

--- a/charts/request-ipfs/values.yaml
+++ b/charts/request-ipfs/values.yaml
@@ -44,6 +44,8 @@ persistence:
   accessModes:
     - ReadWriteOnce
 
+extraEnv: {}
+
 livenessProbe: {}
 
 readinessProbe:

--- a/charts/request-ipfs/values.yaml
+++ b/charts/request-ipfs/values.yaml
@@ -44,6 +44,7 @@ persistence:
   accessModes:
     - ReadWriteOnce
 
+# Additional environment variables to be passed to the IPFS node
 extraEnv: {}
 
 livenessProbe: {}

--- a/charts/request-node/Chart.yaml
+++ b/charts/request-node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 0.31.0
 description: A Helm chart for Request Node
 name: request-node
-version: 0.8.0
+version: 0.8.1
 keywords:
   - request
   - ipfs

--- a/charts/request-node/README.md
+++ b/charts/request-node/README.md
@@ -42,13 +42,13 @@ The following table lists the configurable parameters of the Request Node chart 
 | `ipfs.image.tag`                    | The version tag for the dedicated IPFS server image                                                                    | `0.3.4`                       |
 | `ipfs.image.pullPolicy`             | Dedicated IPFS server image pull policy                                                                                | `Always`                      |
 | `ipfs.swarm.port`                   | Port to access the IPFS swarm                                                                                          | `4001`                        |
-| `ipfs.swarm.externalIP`             | Swarm address to announce to the network (optional). Usually should be the same as `ipfs.swarm.service.loadBalancerIP` |                               |
+| `ipfs.swarm.externalIP`             | Swarm address to announce to the network (optional). Usually should be the same as `ipfs.swarm.service.loadBalancerIP` | `null`                        |
 | `ipfs.swarm.service.enabled`        | Whether to enable the load service to access to IPFS swarm                                                             | `true`                        |
 | `ipfs.swarm.service.type`           | The service type to access the IPFS swarm                                                                              | `LoadBalancer`                |
-| `ipfs.swarm.service.loadBalancerIP` | Static IP address used by the load balancer (optional)                                                                 |                               |
-| `ipfs.identity.peerId`              | The IPFS node PeerID (optional)                                                                                        |                               |
-| `ipfs.identity.privateKey`          | The IPFS node Private Key (optional)                                                                                   |                               |
-| `ipfs.extraEnvs`                    | Additional environment variables to pass down to the IPFS node (optional)                                              |                               |
+| `ipfs.swarm.service.loadBalancerIP` | Static IP address used by the load balancer (optional)                                                                 | `null`                        |
+| `ipfs.identity.peerId`              | The IPFS node PeerID (optional)                                                                                        | `null`                        |
+| `ipfs.identity.privateKey`          | The IPFS node Private Key (optional)                                                                                   | `null`                        |
+| `ipfs.extraEnvs`                    | Additional environment variables to pass down to the IPFS node (optional)                                              | `[]`                          |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/charts/request-node/README.md
+++ b/charts/request-node/README.md
@@ -48,7 +48,7 @@ The following table lists the configurable parameters of the Request Node chart 
 | `ipfs.swarm.service.loadBalancerIP` | Static IP address used by the load balancer (optional)                                                                 | `null`                        |
 | `ipfs.identity.peerId`              | The IPFS node PeerID (optional)                                                                                        | `null`                        |
 | `ipfs.identity.privateKey`          | The IPFS node Private Key (optional)                                                                                   | `null`                        |
-| `ipfs.extraEnvs`                    | Additional environment variables to pass down to the IPFS node (optional)                                              | `[]`                          |
+| `ipfs.extraEnvs`                    | Additional environment variables to pass down to the IPFS node (optional)                                              | `{}`                          |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/charts/request-node/README.md
+++ b/charts/request-node/README.md
@@ -48,6 +48,8 @@ The following table lists the configurable parameters of the Request Node chart 
 | `ipfs.swarm.service.loadBalancerIP` | Static IP address used by the load balancer (optional)                                                                 |                               |
 | `ipfs.identity.peerId`              | The IPFS node PeerID (optional)                                                                                        |                               |
 | `ipfs.identity.privateKey`          | The IPFS node Private Key (optional)                                                                                   |                               |
+| `ipfs.extraEnvs`                    | Additional environment variables to pass down to the IPFS node (optional)                                              |                               |
+
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/charts/request-node/templates/statefulSet.yaml
+++ b/charts/request-node/templates/statefulSet.yaml
@@ -133,6 +133,7 @@ spec:
                 name: {{ include "request-node.fullname" . }}-secret
                 key: ipfsPrivateKey
         {{- end }}
+        # Set additional environment variables for the IPFS container
         {{- range $key, $value := .Values.ipfs.extraEnv }}
         - name: {{ $key }}
           value: {{ tpl $value $ | quote }}

--- a/charts/request-node/templates/statefulSet.yaml
+++ b/charts/request-node/templates/statefulSet.yaml
@@ -133,6 +133,10 @@ spec:
                 name: {{ include "request-node.fullname" . }}-secret
                 key: ipfsPrivateKey
         {{- end }}
+        {{- range $key, $value := .Values.ipfs.extraEnv }}
+        - name: {{ $key }}
+          value: {{ tpl $value $ | quote }}
+        {{- end }}
         resources:
           {{- toYaml .Values.resources.ipfs | nindent 12 }}
 

--- a/charts/request-node/values.yaml
+++ b/charts/request-node/values.yaml
@@ -87,6 +87,7 @@ ipfs:
     service:
       type: ClusterIP
       port: 5001
+  # Additional environment variables to be passed to the IPFS node
   extraEnv: {}
   livenessProbe: {}
   readinessProbe: {}

--- a/charts/request-node/values.yaml
+++ b/charts/request-node/values.yaml
@@ -87,6 +87,7 @@ ipfs:
     service:
       type: ClusterIP
       port: 5001
+  extraEnv: {}
   livenessProbe: {}
   readinessProbe: {}
 


### PR DESCRIPTION
Add options both in the `request-node` and `request-ipfs` charts to pass down additional environment variables to the IPFS Docker container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new configurable parameter `extraEnvs` for specifying additional environment variables in the Request IPFS and Request Node Helm Charts.

- **Updates**
	- Updated the version of the Request IPFS Helm chart from `0.6.11` to `0.6.12` and the Request Node Helm chart from `0.8.0` to `0.8.1`.

- **Improvements**
	- Enhanced configurability of StatefulSets for both Request IPFS and Request Node by allowing dynamic inclusion of environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->