### PR TITLE
fix(request-ipfs): immutable labels on the statefulSet

### DIFF
--- a/charts/request-ipfs/templates/_helpers.tpl
+++ b/charts/request-ipfs/templates/_helpers.tpl
@@ -32,14 +32,21 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Immutable Labels: labels that doesn't change between versions upgrades
+*/}}
+{{- define "request-ipfs.immutable-labels" -}}
+app.kubernetes.io/name: {{ include "request-ipfs.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "request-ipfs.labels" -}}
-app.kubernetes.io/name: {{ include "request-ipfs.name" . }}
+{{ include "request-ipfs.immutable-labels" . }}
 helm.sh/chart: {{ include "request-ipfs.chart" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}

--- a/charts/request-ipfs/templates/statefulSet.yaml
+++ b/charts/request-ipfs/templates/statefulSet.yaml
@@ -3,13 +3,13 @@ kind: StatefulSet
 metadata:
   name: {{ include "request-ipfs.fullname" . }}
   labels:
-{{ include "request-ipfs.labels" . | indent 4 }}
+{{ include "request-ipfs.immutable-labels" . | indent 4 }}
 spec:
   serviceName: {{ .Chart.Name }}
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-{{ include "request-ipfs.labels" . | indent 6 }}
+{{ include "request-ipfs.immutable-labels" . | indent 6 }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
## Description

Labels on the StatefulSet should be immutable between version updates, otherwise, we encounter such errors during upgrades:
> Forbidden: updates to statefulset spec for fields other than 'replicas', 'ordinals', 'template', 'updateStrategy', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden