### PR TITLE
chore(ipfs): update deprecated Docker image

### DIFF
--- a/charts/request-ipfs/Chart.yaml
+++ b/charts/request-ipfs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v0.4.23
 description: A Helm chart for a dedicated Request IPFS node
 name: request-ipfs
-version: 0.6.13
+version: 0.7.0
 keywords:
   - request
   - ipfs

--- a/charts/request-ipfs/Chart.yaml
+++ b/charts/request-ipfs/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.4.26
+appVersion: v0.4.23
 description: A Helm chart for a dedicated Request IPFS node
 name: request-ipfs
 version: 0.6.13

--- a/charts/request-ipfs/README.md
+++ b/charts/request-ipfs/README.md
@@ -28,16 +28,16 @@ $ helm install --name my-release request/request-ipfs
 
 The following table lists the configurable parameters of the Request IPFS chart and their default values.
 
-| Parameter              | Description                                                                                      | Default                     |
-|------------------------|--------------------------------------------------------------------------------------------------|-----------------------------|
-| `replicaCount`         | The amount of replicas to run                                                                    | `1`                         |
+| Parameter              | Description                                                                                      | Default                       |
+|------------------------|--------------------------------------------------------------------------------------------------|-------------------------------|
+| `replicaCount`         | The amount of replicas to run                                                                    | `1`                           |
 | `image.image`          | The docker image for the dedicated IPFS node                                                     | `requestnetwork/request-ipfs` |
-| `image.tag`            | The version tag for the dedicated IPFS node image                                                | `0.4.26`                    |
-| `image.pullPolicy`     | Dedicated IPFS node image pull policy                                                            | `Always`                    |
-| `swarm.loadBalancerIP` | Static IP address used by the load balancer (optional)                                           | `null`                      |
-| `swarm.externalIP`     | Swarm address to announce to the network. Usually same as `ipfs.swarm.loadBalancerIP` (optional) | `null`                      |
-| `identity.peerId`      | The IPFS node PeerID (optional)                                                                  | `null`                      |
-| `identity.privateKey`  | The IPFS node Private Key (optional)                                                             | `null`                      |
+| `image.tag`            | The version tag for the dedicated IPFS node image                                                | `v0.4.23`                     |
+| `image.pullPolicy`     | Dedicated IPFS node image pull policy                                                            | `Always`                      |
+| `swarm.loadBalancerIP` | Static IP address used by the load balancer (optional)                                           | `null`                        |
+| `swarm.externalIP`     | Swarm address to announce to the network. Usually same as `ipfs.swarm.loadBalancerIP` (optional) | `null`                        |
+| `identity.peerId`      | The IPFS node PeerID (optional)                                                                  | `null`                        |
+| `identity.privateKey`  | The IPFS node Private Key (optional)                                                             | `null`                        |
 | `extraEnvs`            | Additional environment variables to pass down to the IPFS node (optional)                        | `{}`                          |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/charts/request-node/Chart.yaml
+++ b/charts/request-node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 0.31.0
 description: A Helm chart for Request Node
 name: request-node
-version: 0.8.1
+version: 0.9.0
 keywords:
   - request
   - ipfs

--- a/charts/request-node/README.md
+++ b/charts/request-node/README.md
@@ -39,7 +39,7 @@ The following table lists the configurable parameters of the Request Node chart 
 | `nodeImage.tag`                     | The version tag for the Request Node image                                                                             | `0.5.5`                       |
 | `nodeImage.pullPolicy`              | Request Node image pull policy                                                                                         | `Always`                      |
 | `ipfs.image.image`                  | The docker image for the dedicated IPFS server                                                                         | `requestnetwork/request-ipfs` |
-| `ipfs.image.tag`                    | The version tag for the dedicated IPFS server image                                                                    | `0.3.4`                       |
+| `ipfs.image.tag`                    | The version tag for the dedicated IPFS server image                                                                    | `v0.4.23`                     |
 | `ipfs.image.pullPolicy`             | Dedicated IPFS server image pull policy                                                                                | `Always`                      |
 | `ipfs.swarm.port`                   | Port to access the IPFS swarm                                                                                          | `4001`                        |
 | `ipfs.swarm.externalIP`             | Swarm address to announce to the network (optional). Usually should be the same as `ipfs.swarm.service.loadBalancerIP` | `null`                        |

--- a/charts/request-node/values.yaml
+++ b/charts/request-node/values.yaml
@@ -68,7 +68,7 @@ ipfs:
   # The IPFS image information
   image:
     image: requestnetwork/request-ipfs
-    tag: 0.4.26
+    tag: v0.4.23
     pullPolicy: Always
   # IPFS swarm port
   swarm:


### PR DESCRIPTION
## Description

This PR updates the default image tag for the `request-ipfs` containers, from `0.4.26` to `v0.4.23`.

The `request-ipfs:0.4.26` image (see [DockerHub](https://hub.docker.com/layers/requestnetwork/request-ipfs/0.4.26/images/sha256-60b93b2f35d4ad43e6abbe196b68fad88cc1586b0e9b1dd7dc46f695ab5b92d5?context=explore)) was using a deprecated versionning notation and actually precedes `request-ipfs:v0.4.23`.

The new notation follows the tag of the base image: [ipfs/go-ipfs](https://hub.docker.com/r/ipfs/go-ipfs) (now [ipfs/kubo](https://hub.docker.com/r/ipfs/kubo/)) ; and the latest image compatible with the Request Network is  `request-ipfs:v0.4.23` (see [DockerHub](https://hub.docker.com/layers/requestnetwork/request-ipfs/v0.4.23/images/sha256-7c17c7ad11cdea97b9717fc41e90362f13db54a601d9ff9b85090ee5b278f67a?context=explore))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the Helm chart for Request IPFS and Request Node with new version tags.
  
- **Bug Fixes**
	- Downgraded the appVersion for Request IPFS to ensure compatibility.
  
- **Documentation**
	- Revised README files for both Request IPFS and Request Node to reflect updated image tags and configuration parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->