### PR TITLE
feat(request-ipfs): allow setting externalIP

### DIFF
--- a/charts/request-ipfs/Chart.yaml
+++ b/charts/request-ipfs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v0.4.23
 description: A Helm chart for a dedicated Request IPFS node
 name: request-ipfs
-version: 0.7.0
+version: 0.8.0
 keywords:
   - request
   - ipfs

--- a/charts/request-ipfs/README.md
+++ b/charts/request-ipfs/README.md
@@ -34,6 +34,7 @@ The following table lists the configurable parameters of the Request IPFS chart 
 | `image.image`                  | The docker image for the dedicated IPFS node                                                                      | `requestnetwork/request-ipfs` |
 | `image.tag`                    | The version tag for the dedicated IPFS node image                                                                 | `v0.4.23`                     |
 | `image.pullPolicy`             | Dedicated IPFS node image pull policy                                                                             | `Always`                      |
+| `swarm.port`                   | Port to access the IPFS swarm                                                                                     | `4001`                        |
 | `swarm.externalIP`             | Swarm address to announce to the network (optional). Usually should be the same as `swarm.service.loadBalancerIP` | `null`                        |
 | `swarm.service.enabled`        | Whether to enable the load service to access to IPFS swarm                                                        | `true`                        |
 | `swarm.service.type`           | The service type to access the IPFS swarm                                                                         | `LoadBalancer`                |

--- a/charts/request-ipfs/README.md
+++ b/charts/request-ipfs/README.md
@@ -28,17 +28,19 @@ $ helm install --name my-release request/request-ipfs
 
 The following table lists the configurable parameters of the Request IPFS chart and their default values.
 
-| Parameter              | Description                                                                                      | Default                       |
-|------------------------|--------------------------------------------------------------------------------------------------|-------------------------------|
-| `replicaCount`         | The amount of replicas to run                                                                    | `1`                           |
-| `image.image`          | The docker image for the dedicated IPFS node                                                     | `requestnetwork/request-ipfs` |
-| `image.tag`            | The version tag for the dedicated IPFS node image                                                | `v0.4.23`                     |
-| `image.pullPolicy`     | Dedicated IPFS node image pull policy                                                            | `Always`                      |
-| `swarm.loadBalancerIP` | Static IP address used by the load balancer (optional)                                           | `null`                        |
-| `swarm.externalIP`     | Swarm address to announce to the network. Usually same as `ipfs.swarm.loadBalancerIP` (optional) | `null`                        |
-| `identity.peerId`      | The IPFS node PeerID (optional)                                                                  | `null`                        |
-| `identity.privateKey`  | The IPFS node Private Key (optional)                                                             | `null`                        |
-| `extraEnvs`            | Additional environment variables to pass down to the IPFS node (optional)                        | `{}`                          |
+| Parameter                      | Description                                                                                                       | Default                       |
+|--------------------------------|-------------------------------------------------------------------------------------------------------------------|-------------------------------|
+| `replicaCount`                 | The amount of replicas to run                                                                                     | `1`                           |
+| `image.image`                  | The docker image for the dedicated IPFS node                                                                      | `requestnetwork/request-ipfs` |
+| `image.tag`                    | The version tag for the dedicated IPFS node image                                                                 | `v0.4.23`                     |
+| `image.pullPolicy`             | Dedicated IPFS node image pull policy                                                                             | `Always`                      |
+| `swarm.externalIP`             | Swarm address to announce to the network (optional). Usually should be the same as `swarm.service.loadBalancerIP` | `null`                        |
+| `swarm.service.enabled`        | Whether to enable the load service to access to IPFS swarm                                                        | `true`                        |
+| `swarm.service.type`           | The service type to access the IPFS swarm                                                                         | `LoadBalancer`                |
+| `swarm.service.loadBalancerIP` | Static IP address used by the load balancer (optional)                                                            | `null`                        |
+| `identity.peerId`              | The IPFS node PeerID (optional)                                                                                   | `null`                        |
+| `identity.privateKey`          | The IPFS node Private Key (optional)                                                                              | `null`                        |
+| `extraEnvs`                    | Additional environment variables to pass down to the IPFS node (optional)                                         | `{}`                          |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/charts/request-ipfs/templates/ipfs-swarm-load-balancer.yaml
+++ b/charts/request-ipfs/templates/ipfs-swarm-load-balancer.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.swarm.service.enabled -}}
+
 # Load balancer to expose the IPFS node swarm port
 apiVersion: v1
 kind: Service
@@ -11,8 +13,10 @@ spec:
     port: {{ .Values.swarm.port }}
     protocol: TCP
     targetPort: 4001
-  loadBalancerIP: {{ .Values.swarm.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.swarm.service.loadBalancerIP }}
   selector:
 {{ include "request-ipfs.labels" . | indent 4 }}
   sessionAffinity: None
-  type: LoadBalancer
+  type: {{ .Values.swarm.service.type }}
+
+{{- end -}}

--- a/charts/request-ipfs/templates/statefulSet.yaml
+++ b/charts/request-ipfs/templates/statefulSet.yaml
@@ -54,6 +54,10 @@ spec:
         # Forces the IPFS node to connect to the Request dedicated network
         - name: LIBP2P_FORCE_PNET
           value: "1"
+        {{- if .Values.ipfs.swarm.externalIP }}
+        - name: EXTERNAL_IP
+          value: {{ .Values.ipfs.swarm.externalIP }}
+        {{- end }}
         {{- if .Values.swarm.port }}
         - name: SWARM_PORT
           value: {{ .Values.swarm.port | quote }}

--- a/charts/request-ipfs/templates/statefulSet.yaml
+++ b/charts/request-ipfs/templates/statefulSet.yaml
@@ -54,9 +54,9 @@ spec:
         # Forces the IPFS node to connect to the Request dedicated network
         - name: LIBP2P_FORCE_PNET
           value: "1"
-        {{- if .Values.ipfs.swarm.externalIP }}
+        {{- if .Values.swarm.externalIP }}
         - name: EXTERNAL_IP
-          value: {{ .Values.ipfs.swarm.externalIP }}
+          value: {{ .Values.swarm.externalIP }}
         {{- end }}
         {{- if .Values.swarm.port }}
         - name: SWARM_PORT

--- a/charts/request-ipfs/values.yaml
+++ b/charts/request-ipfs/values.yaml
@@ -21,7 +21,11 @@ image:
 # IPFS swarm port
 swarm:
   port: 4001
-  loadBalancerIP:
+  externalIP:
+  service:
+    enabled: true
+    type: LoadBalancer
+    loadBalancerIP:
 # IPFS API port
 api:
   port: 5001


### PR DESCRIPTION
## Description

Uniformize request-ipfs config with request-node config:
- add `swarm.externalIP`
- add `swarm.service.enabled`
- add `swarm.service.type`
- move `swarm.loadBalancerIP` to `swarm.service.loadBalancerIP` 